### PR TITLE
[Magiclysm] Magic ring can wear with talons, just like vanilla ring

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_belts.json
+++ b/data/mods/Magiclysm/items/enchanted_belts.json
@@ -23,7 +23,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" },
-    "flags": [ "BELTED", "WATER_FRIENDLY", "STURDY" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY", "STURDY", "OVERSIZE" ],
     "armor": [ { "coverage": 50, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 5 }
   },

--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -14,7 +14,7 @@
     "looks_like": "copper_ring",
     "sided": true,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT" ],
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "ALLOWS_TALONS" ],
     "armor": [
       {
         "encumbrance": 0,
@@ -40,7 +40,7 @@
     "looks_like": "silver_ring",
     "sided": true,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT" ],
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "ALLOWS_TALONS" ],
     "armor": [
       {
         "encumbrance": 0,
@@ -66,7 +66,7 @@
     "looks_like": "gold_ring",
     "sided": true,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT" ],
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "ALLOWS_TALONS" ],
     "armor": [
       {
         "encumbrance": 0,
@@ -92,7 +92,7 @@
     "looks_like": "platinum_ring",
     "sided": true,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT" ],
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "ALLOWS_TALONS" ],
     "armor": [
       {
         "encumbrance": 0,


### PR DESCRIPTION
#### Summary
Mods "[Magiclysm] Magic ring can wear with talons, just like vanilla ring"

#### Purpose of change
Magic rings don't have `ALLOWS_TALONS` but vanilla ones have, this is aim for fix that.

#### Describe the solution
Add  `ALLOWS_TALONS` to magic rings

#### Describe alternatives you've considered
Don't

#### Testing

#### Additional context
